### PR TITLE
fix roles and remove multitenancy flag from pebble layer

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -65,15 +65,15 @@ resources:
 # Based on: https://grafana.com/docs/loki/latest/get-started/deployment-modes/#simple-scalable
 config:
   options:
-    read:
+    role-read:
       type: boolean
       default: false
-    write:
+    role-write:
       type: boolean
       default: false
-    backend:
+    role-backend:
       type: boolean
       default: false
-    all:
+    role-all:
       type: boolean
       default: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -86,7 +86,7 @@ class LokiWorkerK8SOperatorCharm(CharmBase):
                     "loki": {
                         "override": "replace",
                         "summary": "loki worker daemon",
-                        "command": f"/bin/loki --config.file={CONFIG_FILE} -target {targets} -auth.multitenancy-enabled=false",
+                        "command": f"/bin/loki --config.file={CONFIG_FILE} -target {targets}",
                         "startup": "enabled",
                     }
                 },

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ import logging
 import re
 from typing import Optional
 
-from cosl.coordinated_workers.worker import CERT_FILE, CONFIG_FILE, Worker
+from cosl.coordinated_workers.worker import CONFIG_FILE, Worker
 from ops.charm import CharmBase
 from ops.main import main
 from ops.pebble import Layer
@@ -27,7 +27,7 @@ class LokiWorkerK8SOperatorCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self._worker = Worker(
+        self.worker = Worker(
             charm=self,
             name="loki",
             pebble_layer=self.pebble_layer,
@@ -47,17 +47,6 @@ class LokiWorkerK8SOperatorCharm(CharmBase):
         )
 
     # === PROPERTIES === #
-
-    @property
-    def server_cert_path(self) -> Optional[str]:
-        """Server certificate path for tls tracing."""
-        return CERT_FILE
-
-    @property
-    def tempo_endpoint(self) -> Optional[str]:
-        """Tempo endpoint for charm tracing."""
-        if self._worker.tracing.is_ready():
-            return self._worker.tracing.get_endpoint(protocol="otlp_http")
 
     @property
     def version(self) -> Optional[str]:


### PR DESCRIPTION
Differently from Mimir, Loki HA disables multitenancy in the config file, not in the binary execution.

https://grafana.com/docs/loki/latest/configure/#supported-contents-and-default-values-of-lokiyaml

---

The PR also cleans up charm tracing from the worker, since it's now configured in the `coordinated_workers.worker` shared object.

---

It also fixes the roles to start with `role-`, as we do in our HA charms.