### PR TITLE
[tf] Update the outputs.tf with endpoints nomenclature

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -6,7 +6,6 @@ output "endpoints" {
   value = {
     # Requires
     loki_cluster = "loki-cluster"
-    
     # Provides
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,7 +2,7 @@ output "app_name" {
   value = juju_application.loki_worker.name
 }
 
-output "requires" {
+output "endpoints" {
   value = {
     loki_cluster = "loki-cluster"
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,6 +4,9 @@ output "app_name" {
 
 output "endpoints" {
   value = {
+    # Requires
     loki_cluster = "loki-cluster"
+    
+    # Provides
   }
 }


### PR DESCRIPTION
To remove implementation detail of the TF module when another module inherits it, it makes sense to replace the `requires` and `provides` output variables with `endpoints`.

Coordinating PR
- https://github.com/canonical/observability/pull/226