### PR TITLE
feat: respect http(s) proxy variables

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,7 @@
 """Charm the service."""
 
 import logging
+import os
 import re
 import socket
 from typing import Optional
@@ -83,8 +84,16 @@ class LokiWorkerK8SOperatorCharm(CharmBase):
         """Return a dictionary representing a Pebble layer."""
         targets = ",".join(sorted(worker.roles))
 
-        # configure workload traces
         env = {}
+        # add proxy variables
+        env.update(
+            {
+                "https_proxy": os.environ.get("JUJU_CHARM_HTTPS_PROXY", ""),
+                "http_proxy": os.environ.get("JUJU_CHARM_HTTP_PROXY", ""),
+                "no_proxy": os.environ.get("JUJU_CHARM_NO_PROXY", ""),
+            }
+        )
+        # configure workload traces
         if tempo_endpoint := worker.cluster.get_workload_tracing_receivers().get(
             "jaeger_thrift_http", None
         ):


### PR DESCRIPTION
## Issue

Closes #57 

## Solution

Pass the proxy variables to the Pebble layer environment. The `JUJU_*` variables are set in the charm context by Juju.