### PR TITLE
chore: bump coordinated workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ version = "0.0"
 requires-python = "~=3.8"
 
 dependencies = [
-  "coordinated-workers>=2.0.14",
+  "coordinated-workers",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1113,7 +1113,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "codespell", marker = "extra == 'dev'" },
-    { name = "coordinated-workers", specifier = ">=2.0.14" },
+    { name = "coordinated-workers" },
     { name = "coverage", extras = ["toml"], marker = "extra == 'dev'" },
     { name = "juju", marker = "extra == 'dev'" },
     { name = "ops", extras = ["testing"], marker = "extra == 'dev'" },


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
In tandem with [the PR](https://github.com/canonical/cos-coordinated-workers/pull/56) in `cos-coordinated-workers`. 

## Solution
<!-- A summary of the solution addressing the above issue -->
This PR bumps the `coordinated-workers` version to >= v2.0.14.
Also does a `fetch lib`.
## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
